### PR TITLE
Fix responsive images

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -153,16 +153,18 @@ class App extends Component {
           submit={this.searchHandler}
           fileInputRef={(input) => this.fileInput = input}
           urlInputRef={(input) => this.urlInput = input} />
-        {/*  <br/> */}
+         {/* <br/> */}
+
           <main> 
           {this.state.finished ? <span id="goal-message">{this.state.finishedMessage}</span> : <span id="goal-message">Your need to find a {this.state.goal}</span>}
-            {/*<br />*/}
+            <br />
             {this.state.searching && <span>{this.state.searchingMessage}</span>} 
             {(!this.state.searching && this.state.searched )&& <Checker tags={this.state.tags} goal={this.state.goal} randomGoal={this.randomGoal} remainingGoals={this.state.goals.length}/>}
-        {/*    <br/><br/> */}
+           <br/><br/>
             {this.state.image && <div id="searched-image"><img alt="your find" src={this.state.image}  id="searched-image-img" /></div>}
           </main>
-          <br/>
+          {/* <br/> */}
+
         <footer>
           <p>&copy; {new Date().getFullYear()}. All Rights Reserved.</p>
         </footer>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -156,7 +156,7 @@ class App extends Component {
          {/* <br/> */}
 
           <main> 
-          {this.state.finished ? <span id="goal-message">{this.state.finishedMessage}</span> : <span id="goal-message">Your need to find a {this.state.goal}</span>}
+          {this.state.finished ? <span id="goal-message">{this.state.finishedMessage}</span> : <span id="goal-message">You need to find a {this.state.goal}</span>}
             <br />
             {this.state.searching && <span>{this.state.searchingMessage}</span>} 
             {(!this.state.searching && this.state.searched )&& <Checker tags={this.state.tags} goal={this.state.goal} randomGoal={this.randomGoal} remainingGoals={this.state.goals.length}/>}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -157,10 +157,10 @@ class App extends Component {
 
           <main> 
           {this.state.finished ? <span id="goal-message">{this.state.finishedMessage}</span> : <span id="goal-message">You need to find a {this.state.goal}</span>}
-            <br />
+            {/* <br /> */}
             {this.state.searching && <span>{this.state.searchingMessage}</span>} 
             {(!this.state.searching && this.state.searched )&& <Checker tags={this.state.tags} goal={this.state.goal} randomGoal={this.randomGoal} remainingGoals={this.state.goals.length}/>}
-           <br/><br/>
+           {/* <br/><br/> */}
             {this.state.image && <div id="searched-image"><img alt="your find" src={this.state.image}  id="searched-image-img" /></div>}
           </main>
           {/* <br/> */}

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -65,7 +65,7 @@ header form input[type="submit"] {
 #searched-image img {
   display: block;
   margin: 0 auto;
-  min-width: 50vw;
+  /* min-width: 50vw; */
   width: 100%; /* Makes images responsive. Parent is `main` */
 }
 
@@ -88,6 +88,7 @@ header form input[type="submit"] {
 footer {
   width: 100%;
   height: 50px;
+  margin-top: 3em;
   /* position: fixed; */
   bottom: 0;
   background-color: var(--mintGreen);
@@ -103,6 +104,9 @@ footer p { text-align: center; }
 @media screen and (min-width: 55rem) {
   .App main {
     width: 55rem;
+  }
+  #searched-image img {
+    width: 80%;
   }
 }
 
@@ -153,10 +157,12 @@ header h1 {
 
   main {
     display: grid;
+    align-items: start;
+    grid-auto-rows: minmax(min-content, max-content);
   }
 
   #goal-message {
-    display: block;
+    display: block; /* Can't add margin-top to inline */
     margin-top: 20px;
     /* align-self: start; */
   }

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -11,7 +11,9 @@
     Typography
 ========================================================== */
 
-header h1 { display: inline-block; }
+header h1 { 
+  display: inline-block; 
+}
 
 /* ======================================================= 
     Styles
@@ -63,21 +65,27 @@ header form input[type="submit"] {
 #searched-image img {
   display: block;
   margin: 0 auto;
+  width: 100%;
+  /* min-width: 100%; */
+  /* max-width: 100%;  */
+  /* parent is main */
 }
 
-@media screen and (min-width: 768px) {
+/* @media screen and (min-width: 768px) {
   #searched-image img {
-    width: 50%;
-    height: auto;
+    /* width: 50%; * /
+    width: 100%
+    /* height: auto; * /
   }
-}
+} */
 
-@media screen and (max-width: 500px) {
+/* @media screen and (max-width: 500px) {
   #searched-image img {
-    width: 80%;
-    height: auto;
+    /* width: 80%; * /
+    width: 100%; /* Crucial for mobile viewports, otherwise header & footer get cut off */
+    /* height: auto; * /
   }
-}
+} */
 
 footer {
   width: 100%;
@@ -85,7 +93,7 @@ footer {
   /* position: fixed; */
   bottom: 0;
   background-color: var(--mintGreen);
-  background-color: #13e28c;
+  /* background-color: #13e28c; */
 }
 
 footer p { text-align: center; }
@@ -104,8 +112,8 @@ footer p { text-align: center; }
 
 .App main {
   /* width: 33em; */
-  max-width: 33em;
-  max-width: 50em;
+  /* max-width: 50em; */
+  max-width: 55rem; /* constrains image width */
   margin: 0 auto;
 }
 
@@ -118,7 +126,7 @@ header h1 {
 
 .header-container {
   /* max-width: 50em; */
-  max-width: 55em;
+  max-width: 55rem;
   display: flex;
   margin: 0 auto;
   /* width: 60em; */
@@ -135,10 +143,10 @@ header h1 {
     grid-template-rows: auto 1fr auto;
   }
 
-  main {
+  /* main {
     display: grid;
 
-  }
+  } */
 
   #goal-message {
     margin-top: 20px;

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -65,6 +65,7 @@ header form input[type="submit"] {
 #searched-image img {
   display: block;
   margin: 0 auto;
+  min-width: 50vw;
   width: 100%;
   /* min-width: 100%; */
   /* max-width: 100%;  */

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -66,10 +66,7 @@ header form input[type="submit"] {
   display: block;
   margin: 0 auto;
   min-width: 50vw;
-  width: 100%;
-  /* min-width: 100%; */
-  /* max-width: 100%;  */
-  /* parent is main */
+  width: 100%; /* Makes images responsive. Parent is `main` */
 }
 
 /* @media screen and (min-width: 768px) {
@@ -98,6 +95,16 @@ footer {
 }
 
 footer p { text-align: center; }
+
+/* ======================================================= 
+    Media Queries
+========================================================== */
+
+@media screen and (min-width: 55rem) {
+  .App main {
+    width: 55rem;
+  }
+}
 
 /* ======================================================= 
     Layout
@@ -144,13 +151,14 @@ header h1 {
     grid-template-rows: auto 1fr auto;
   }
 
-  /* main {
+  main {
     display: grid;
-
-  } */
+  }
 
   #goal-message {
+    display: block;
     margin-top: 20px;
+    /* align-self: start; */
   }
 
   #checker {


### PR DESCRIPTION
This pull request fixes images being resized too small. 
It also stretches small images to make them fill the specified space. 

For viewports 55 rem or wider, images will always be 80% of 55 rem (~704 px).
For viewports narrower than 55 rem, images will always be 100% of its container's size. In retrospect, this yields unreliable results. If the image is large, the size of its container is determined by the image itself; therefore, the image's width will be approximately be the viewport width. If the image is small, the size of its container is determined by the text inside the container. 
This will be fixed in a future commit.
 